### PR TITLE
Add mapKeyValues helper function

### DIFF
--- a/test/mongo-utils.test.js
+++ b/test/mongo-utils.test.js
@@ -864,3 +864,77 @@ describe('mapQuery', function () {
         });
     });
 });
+
+describe('mapKeyValues', function () {
+    it('Is able to replace both keys and values', function () {
+        const query = {
+            good: true
+        };
+
+        const transformer = mongoUtils.mapKeyValues({
+            key: {
+                from: 'good',
+                to: 'bad'
+            },
+            values: [{
+                from: true,
+                to: false
+            }, {
+                from: false,
+                to: true
+            }]
+        });
+
+        transformer(query).should.eql({
+            bad: false
+        });
+    });
+
+    it('Is able to replace nested keys and values', function () {
+        const query = {
+            $and: [{
+                good: {
+                    $ne: false
+                }
+            }, {
+                $or: [{
+                    something: 'else'
+                }, {
+                    good: {
+                        $ne: true
+                    }
+                }]
+            }]
+        };
+
+        const transformer = mongoUtils.mapKeyValues({
+            key: {
+                from: 'good',
+                to: 'bad'
+            },
+            values: [{
+                from: true,
+                to: false
+            }, {
+                from: false,
+                to: true
+            }]
+        });
+
+        transformer(query).should.eql({
+            $and: [{
+                bad: {
+                    $ne: true
+                }
+            }, {
+                $or: [{
+                    something: 'else'
+                }, {
+                    bad: {
+                        $ne: false
+                    }
+                }]
+            }]
+        });
+    });
+});


### PR DESCRIPTION
This has been pulled out from https://github.com/TryGhost/Ghost/tree/master/core/shared/nql-map-key-values

The function takes objects with `from` and `to` properties and returns a transformer function, which can be used with the `@nexes/nql` library.

The transformer will change all keys that are equal to the key `from` into `to`, and then iterate that keys values and replaces them according to the values' `from` and `to`'s